### PR TITLE
Add local tensor serialization examples

### DIFF
--- a/deserialize_local.py
+++ b/deserialize_local.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+"""Deserialize tensors and generate text with gpt-neo-125M."""
+
+import torch
+from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer
+from tensorizer import TensorDeserializer
+from tensorizer.utils import no_init_or_tensor
+
+MODEL_NAME = "EleutherAI/gpt-neo-125M"
+TENSOR_PATH = "gpt-neo-125M.tensors"
+
+def main() -> None:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    config = AutoConfig.from_pretrained(MODEL_NAME)
+    with no_init_or_tensor():
+        model = AutoModelForCausalLM.from_config(config, torch_dtype=torch.float16)
+    deserializer = TensorDeserializer(TENSOR_PATH)
+    deserializer.load_into_module(model)
+    deserializer.close()
+    model.to(device)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_NAME)
+    inputs = tokenizer("Hello", return_tensors="pt").to(device)
+    model.eval()
+    with torch.no_grad():
+        outputs = model.generate(**inputs, max_new_tokens=12)
+    print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+
+if __name__ == "__main__":
+    main()

--- a/serialize_local.py
+++ b/serialize_local.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+"""Serialize EleutherAI/gpt-neo-125M to a local tensor file."""
+
+import torch
+from transformers import AutoModelForCausalLM
+from tensorizer import TensorSerializer
+
+MODEL_NAME = "EleutherAI/gpt-neo-125M"
+TENSOR_PATH = "gpt-neo-125M.tensors"
+
+def main() -> None:
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_NAME,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+    ).to(device)
+    serializer = TensorSerializer(TENSOR_PATH)
+    serializer.write_module(model)
+    serializer.close()
+    print(f"Serialized to {TENSOR_PATH}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `serialize_local.py` for saving EleutherAI/gpt-neo-125M to a tensor file
- add `deserialize_local.py` to rebuild model from tensors and run generation

## Testing
- `pytest -q`
- `python serialize_local.py` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*
- `python deserialize_local.py` *(fails: ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b4d66f5a848323b7e401792d1f914b